### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ than typical open source software project repositories:
   this branch is essentially empty.
 * The **Working** branch is where all work-in-progress content is
   captured, and is the place to go for the [current working
-  version](imjadn-v1.0-cn01.md) of this work product.
+  version](https://github.com/oasis-tcs/openc2-jadn-im/blob/working/imjadn-v1.0-cn02.md) of this work product.
 
 More information about the TC's repository organizing conventions
 and branching strategy can be found in our [Documentation


### PR DESCRIPTION
If new readers go to the main readme on the opening (ie "published" branch) page and click on the link that says "and is the place to go for the current working version" - they don't end up on the current working version. They end up on a past approved version in published. This is an attempt to fix that link.